### PR TITLE
Restore text colors for alias and session tags

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
+    experimentalSessionAndOrigin: true,
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/spec4.cy.js
+++ b/cypress/e2e/spec4.cy.js
@@ -1,0 +1,47 @@
+describe('alias and session', () => {
+  let valid = 'ok';
+
+  before(() => {
+    Cypress.session.clearAllSavedSessions();
+    cy.session(
+      '1',
+      () => {},
+      {
+        validate() {
+          if (valid !== 'ok') {
+            valid = 'ok'; // Reset the flag.
+            return false;
+          }
+
+          return valid === 'ok'
+        }
+      });
+  })
+
+  it('shows aliases', () => {
+    cy.intercept('GET', '**/comments/*').as('getComment')
+    cy.intercept('POST', '**/comments') // Unnamed alias
+
+    cy.visit('https://example.cypress.io/commands/network-requests')
+
+    cy.contains('Get Comment').click();
+    cy.contains('Post Comment').click();
+
+    cy.contains('POST successful!').should('be.visible');
+  })
+
+  it('shows session', () => {
+    cy.visit('https://example.cypress.io')
+  })
+
+  it('shows restored session', () => {
+    cy.session('1');
+    cy.visit('https://example.cypress.io')
+  })
+
+  it('shows recreated session', () => {
+    valid = 'not ok' // Force recreation.
+    cy.session('1');
+    cy.visit('https://example.cypress.io')
+  })
+})

--- a/index.js
+++ b/index.js
@@ -395,6 +395,31 @@ function addStyleEL() {
     background-color: #B7E7F0 !important
   }
 
+  span.reporter-tag.reporter-tag-content.successful-status {
+    color: #69d3a7 !important;
+  }
+  span.reporter-tag.reporter-tag-content.warned-status {
+    color: #edbb4a !important;
+  }
+  span.reporter-tag.reporter-tag-content.route.command-interceptions {
+    color: #e1e3ed !important;
+  }
+  span.reporter-tag.reporter-tag-content.route.command-interceptions .status {
+    color: #e1e3ed !important;
+  }
+  span.reporter-tag.reporter-tag-content.route.command-interceptions em.no-alias {
+    color: #e1e3ed !important;
+  }
+  span.reporter-tag.reporter-tag-content.route.command-alias {
+    color: #e1e3ed !important;
+  }
+  span.reporter-tag.reporter-tag-content.route.route-alias-name {
+    color: #e1e3ed !important;
+  }
+  .sessions-container .session-content .session-item-wrapper:hover {
+    background-color: #f3f4fa !important;
+  }
+
   `
   reporterEl.appendChild(styleEl)
 }


### PR DESCRIPTION
Fixes #2
Restores the text colors for aliases (light on purple) and sessions (green or yellow on black)
Examples:
![example1](https://github.com/marktnoonan/cypress-light-theme/assets/103196273/153be739-ff62-4797-8fbe-c3180e21af40)
From the created spec:
![example2](https://github.com/marktnoonan/cypress-light-theme/assets/103196273/700e3c8c-96ac-474b-a1ac-50d6b0324bd3)

