### PR TITLE
Type definition for the project

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -54,6 +54,19 @@ module.exports = defineConfig({
 
 This can be overridden by setting `CYPRESS_THEME` from the command line. [Learn more about how environment variables work in Cypress](https://on.cypress.io/environment-variables).
 
+### Types
+
+To add [TypeScript support](https://www.typescriptlang.org/tsconfig/#types) for this module, you may need to add this project name to your `tsconfig.json`:
+```json
+{
+  "compilerOptions": {
+    "types": [
+      "cypress-light-theme"
+    ]
+  }
+}
+```
+
 ## Development
 
 ```sh

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,24 @@
+declare module 'cypress-light-theme' {
+  /**
+   * Sets the theme of the Cypress command log, using the environment settings.
+   * Defaults to `system`. Can be set to `light` or `dark` using the `THEME` configuration.
+   * (Alternatively, the `CYRPRESS_THEME` environment variable, from the command line).
+   * 
+   * @example
+   ```
+   // e2e.js or component.js
+   import setLightTheme from 'cypress-light-theme'
+   setLightTheme();
+
+   // Optionally:
+   // cypress.config.js
+   const { defineConfig } = require('cypress')
+   module.exports = defineConfig({
+       env: {
+           THEME: 'light' // or 'dark' or 'system'
+       }
+   });
+   ```
+   */
+  export default function setLightTheme(): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@ declare module 'cypress-light-theme' {
   /**
    * Sets the theme of the Cypress command log, using the environment settings.
    * Defaults to `system`. Can be set to `light` or `dark` using the `THEME` configuration.
-   * (Alternatively, the `CYRPRESS_THEME` environment variable, from the command line).
+   * (Alternatively, the `CYPRESS_THEME` environment variable, from the command line).
    * 
    * @example
    ```

--- a/index.js
+++ b/index.js
@@ -405,6 +405,27 @@ function removeStyleElIfPresent() {
     top.document.getElementById(STYLE_EL_ID).remove()
   }
 }
+/**
+ * Sets the theme of the Cypress command log, using the environment settings.
+ * Defaults to `system`. Can be set to `light` or `dark` using the `THEME` configuration.
+ * (Alternatively, the `CYRPRESS_THEME` environment variable, from the command line).
+ * 
+ * @example
+ ```
+ // e2e.js or component.js
+ import setLightTheme from 'cypress-light-theme'
+ setLightTheme();
+
+ // Optionally:
+ // cypress.config.js
+ const { defineConfig } = require('cypress')
+ module.exports = defineConfig({
+     env: {
+         THEME: 'light' // or 'dark' or 'system'
+     }
+ });
+ ```
+ */
 export default function setLightTheme() {
   removeStyleElIfPresent()
   // get theme from env var

--- a/index.js
+++ b/index.js
@@ -408,7 +408,7 @@ function removeStyleElIfPresent() {
 /**
  * Sets the theme of the Cypress command log, using the environment settings.
  * Defaults to `system`. Can be set to `light` or `dark` using the `THEME` configuration.
- * (Alternatively, the `CYRPRESS_THEME` environment variable, from the command line).
+ * (Alternatively, the `CYPRESS_THEME` environment variable, from the command line).
  * 
  * @example
  ```

--- a/package.json
+++ b/package.json
@@ -14,5 +14,6 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/marktnoonan/cypress-light-theme.git"
-  }
+  },
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Fixes #1 

- Adds a module declaration, so that `setLightTheme` can be used in .ts files.
- Adds to the readme for how this is set up.
- Adds JSDoc for the exported `setLightTheme` function (both in the declaration and the original)

Tested by locally installing this project and seeing that the type declaration error (as seen in the issue) no longer appears. Also now shows with docs in the IDE (VSCode):

![image](https://github.com/marktnoonan/cypress-light-theme/assets/103196273/85f8a185-9b9a-417a-8c00-7cc8f7445a1e)
